### PR TITLE
fix Spore translation

### DIFF
--- a/public/locales/en/seed49.json
+++ b/public/locales/en/seed49.json
@@ -128,7 +128,7 @@
   "돼지": "Pig",
   "리본 돼지": "Ribbon Pig",
   "뿔버섯": "Horny Mushroom",
-  "스포아": "Shroom",
+  "스포아": "Spore",
   "이상한 돼지": "Strange Pig",
   "파란 리본돼지": "Blue Ribbon Pig",
   "장난감 목마": "Toy Trojan",


### PR DESCRIPTION
On floor 49 -> 스포아 should be translated as "Spore". "Shroom" is marked as a wrong answer.
See recording from GMS below. 

![o1](https://user-images.githubusercontent.com/76797368/191090268-0ed858ce-4e7a-4f38-9f6c-9f1cff171efd.gif)

